### PR TITLE
Silliness Reduction

### DIFF
--- a/HelloWorld.Tests/HelloWorldTests.cs
+++ b/HelloWorld.Tests/HelloWorldTests.cs
@@ -1,32 +1,35 @@
+using System.Diagnostics;
+using System.Reflection;
+
 namespace HelloWorld.Tests;
 
 public class HelloWorldTests
 {
     [Fact]
-    public void HelloWorld_Prints_HelloWorld()
+    public void HelloWorld_Prints_HelloWorldEx()
     {
         // Arrange
-        var writer = new StringWriter();
-        Console.SetOut(writer);
+        var location = Assembly.GetExecutingAssembly().Location;
+        var baseDir = location.Remove(
+        location.IndexOf(
+            "\\HelloWorld.Tests\\bin\\Debug\\net8.0\\HelloWorld.Tests.dll", StringComparison.InvariantCultureIgnoreCase));
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo("dotnet", $"run --project {baseDir}\\HelloWorld\\HelloWorld.csproj")
+            {
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
 
         // Act
-        Program.Main(default!);
+        process.Start();
+        process.WaitForExit();
+
+        var output = process.StandardOutput.ReadToEnd();
 
         // Assert
-        Assert.Equal("Hello, World!", writer.ToString().Trim());
-    }
-
-    [Fact]
-    public void HelloWorld_Never_Wawaweewah()
-    {
-        // Arrange
-        var writer = new StringWriter();
-        Console.SetOut(writer);
-
-        // Act
-        Program.Main(default!);
-
-        // Assert
-        Assert.NotEqual("Wawaweewah!", writer.ToString().Trim());
+        Assert.Equal("Hello, World!\r\n", output);
     }
 }

--- a/HelloWorld/AssemblyInfo.cs
+++ b/HelloWorld/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("HelloWorld.Tests")]

--- a/HelloWorld/Program.cs
+++ b/HelloWorld/Program.cs
@@ -1,8 +1,1 @@
-﻿internal class Program
-{
-    internal static void Main(string[] args)
-    {
-        // This is a simple C# program that prints "Hello, World!" to the console.
-        Console.WriteLine("Hello, World!");
-    }
-}
+﻿Console.WriteLine("Hello, World!");

--- a/README.md
+++ b/README.md
@@ -2,17 +2,9 @@
  
  # Hello World
 
-Since I can't publicly share 99.999% of my code on GitHub, here's a _simple_ Hello World program in C# to show you how _not_ to code.
+Technically its the default project template for a C# Console App, ostensibly a 1 line program thanks to Top Level Statements. 
 
-Realistically, this is a MarkDown project about problem solving with snippets of C#, exposeing how bloody silly and frustrating coding can be.
-
-![image](/attachments/inconceivable1.gif)
-
-Technically its the default project template for a C# Console App, but we can't 💯% test that. A crying shame, because this is ostensibly a 1 line program thanks to Top Level Statements. But the whole thing unravels quickly if you have the audacity to test it.
-
-\#TLDR Probably don't.
-
-## Starting Template
+**Starting Template & Finished App**
 
 ![image](attachments/consoleapp.png)
 
@@ -22,28 +14,7 @@ So to make it testable, we add a test project.
 
 1. Add an `XUnit` test project.
 1. Add a reference the `HelloWorld` project.
-   >Error: Main is inaccessible, your tests can't see it.
-
-This is frustrating, but by default Top Level Statements gives you this implementation under the hood:
-
-```csharp
-internal class Program
-{
-    static void Main(string[] args)
-    {
-        // This is a simple C# program that prints "Hello, World!" to the console.
-        Console.WriteLine("Hello, World!");
-    }
-}
-```
-
-The `internal` for `Program` looks promising, but sadly `Main` defaults to `private`. That's our problem.
-
-So we lose our beautiful 1-liner, just so we can set `Program` and `Main` to `public`.
-
-Cool, now we can add tests and they'll pass.
-
-`Pro Tip:` If you're doing TDD, remember to _pretend_ you wrote the failing tests _before_ you wrote the code to make them pass.
+1. Add this test:
 
 ```csharp
 namespace HelloWorld.Tests;
@@ -51,40 +22,36 @@ namespace HelloWorld.Tests;
 public class HelloWorldTests
 {
     [Fact]
-    public void HelloWorld_Prints_HelloWorld()
+    public void HelloWorld_Prints_HelloWorldEx()
     {
         // Arrange
-        var writer = new StringWriter();
-        Console.SetOut(writer);
+        var location = Assembly.GetExecutingAssembly().Location;
+        var baseDir = location.Remove(
+        location.IndexOf(
+            "\\HelloWorld.Tests\\bin\\Debug\\net8.0\\HelloWorld.Tests.dll", StringComparison.InvariantCultureIgnoreCase));
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo("dotnet", $"run --project {baseDir}\\HelloWorld\\HelloWorld.csproj")
+            {
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
 
         // Act
-        Program.Main(default!);
+        process.Start();
+        process.WaitForExit();
+
+        var output = process.StandardOutput.ReadToEnd();
 
         // Assert
-        Assert.Equal("Hello, World!", writer.ToString().Trim());
-    }
-
-    [Fact]
-    public void HelloWorld_Never_Wawaweewah()
-    {
-        // Arrange
-        var writer = new StringWriter();
-        Console.SetOut(writer);
-
-        // Act
-        Program.Main(default!);
-
-        // Assert
-        Assert.NotEqual("Wawaweewah!", writer.ToString().Trim());
+        Assert.Equal("Hello, World!\r\n", output);
     }
 }
 ```
 
-Great! Now everything is `public`. 🤦‍♂️ _**Inconceivable**_!
-
-![image](attachments/hitchhikers1.gif)
-
-We'll fix that later.
+`Pro Tip:` If you're doing TDD, remember to _pretend_ you wrote the failing tests _before_ you wrote the code to make them pass.
 
 ## Problem 2: Measuring Code Coverage
 
@@ -120,46 +87,18 @@ Amazing, 💯% code coverage!
 
 `Pro Tip:` If it doesn't generate `coverage.opencover.xml`, you've successfully reproduced my results. Somethings broken and needs fixing. Good luck!
 
-![image](attachments/sparklemotion.gif)
-
 Congratulations, you're a real Software Engineer now!
-
-## Problem 3: Retaining some dignity
-
-Technically, (nobody cares, but...) `public` is bad. Okay, so is chasing 💯% code coverage. But it's ONE LINE of code, so 100% isn't crazy!
-
-Anyway, since `public` compromised encapsulation and security, we should really make them both `internal`, and give exclusive access only to our tests.
-
-Applying some compiler wizardry 🧙‍♂️ in an `AssemblyInfo.cs`, we specify `InternalsVisibleTo` to make it so.
-
-```csharp
-[assembly: InternalsVisibleTo("HelloWorld.Tests")]
-```
-
-Problem Solved! But adding `AssemblyInfo.cs` has really screwed up our 1-liner and dropped the code coverage below 💯%. _**Inconceivable!**_
-
-## Problem 4: Achieving 100% test coverage
-
-Ironically, adding `AssemblyInfo.cs` to facillitate testing the code to 💯%, adds a bit of code we can't bloody test!
-
-This impacts the code coverage, so we exclude that from code coverage.
-
-```powershell
-dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[HelloWorldCSharp]*AssemblyInfo.cs"
-```
 
 ## Conclusion
 
-Much of this sillyness can be avoided, by:
+Technically, `Main` is the entrypoint of `Program`, so testing it is technically an End-to-End test anyway! 
 
-- Creating an `internal` HelloWorld class
-- Not chasing minimalism and 💯% code coverage
-- Buy a Visual Studio Enterprise license
+We might as well test the whole process, right? 
 
-Technically, `Main` is the entrypoint of `Program`, so testing it is technically an End-to-End test anyway!
+![image](attachments/sparklemotion.gif)
 
-Of course, all of this is _**inconceviable!**_ for a Hello World app and all of this is _very_ _VERY_ silly.
+Well, no. That's not how we do things. We test the smallest unit of code that we can, and we test it in isolation.
 
-![image](attachments/inconceivable2.gif)
+This is a silly example.
 
-If you don't like sillyness, probably don't write code. It's sillyness _all_ the way down!
+


### PR DESCRIPTION
This PR represents a motion to usher in a regime change, reducing the overall silliness and levity of this entire project. 

- Test process output instead of code invocation
- Restored Top Level Statements
- Removed AssemblyInfo.cs
- Obliterates the comedy of errors

It also reduces the amount of code, thus the liability it represents. 